### PR TITLE
USearch: Fix version mismatch

### DIFF
--- a/recipes/usearch/all/conandata.yml
+++ b/recipes/usearch/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.18.8":
-    url: "https://github.com/unum-cloud/usearch/archive/v0.18.8.tar.gz"
-    sha256: "069072fa5ad6817f24fa1d2599dac41263c78096bccb97382d6447c733df279d"
+  "2.4.0":
+    url: "https://github.com/unum-cloud/usearch/archive/v2.4.0.tar.gz"
+    sha256: "cc9ed7cf978b53a44f3a383b6172734647d4b6c4d9868b286b67be6202e6ba1b"

--- a/recipes/usearch/all/conanfile.py
+++ b/recipes/usearch/all/conanfile.py
@@ -1,4 +1,5 @@
-# To test, please run: conan create all/conanfile.py --version 0.8.0
+
+# To test, please run: conan create all/conanfile.py --version 2.4.0
 import os
 
 from conan import ConanFile

--- a/recipes/usearch/config.yml
+++ b/recipes/usearch/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.8.0":
+  "2.4.0":
     folder: all


### PR DESCRIPTION
I'm submitting usearch/2.4.0 to Conan.
The recipe was designed and tested with Conan v1.59.0 on Ubuntu 22.04.
